### PR TITLE
fix: reflect file name as main to the necessary files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 EXPOSE 5000
 
 # Define environment variable
-ENV FLASK_APP=app.py
+ENV FLASK_APP=main.py
 
-# Run app.py when the container launches
+# Run main.py when the container launches
 CMD ["flask", "run", "--host=0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ export MONGO_URI=mongodb://localhost:27017/
 export API_KEY=very_secret_api_key
 python main.py
 ```
+or all stack with single command
+```sh
+podman-compose up -d
+```
 
 ## Examples
 ```sh

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,27 @@
+version: '3.8'
+
+services:
+  mongodb:
+    image: mongo:4.2
+    container_name: mongodb
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo-data:/data/db
+
+  btc-app:
+    image: boranx/btc-app:latest
+    container_name: btc-app
+    build: .
+    ports:
+      - "5000:5000"
+    environment:
+      - MONGO_URI=mongodb://mongodb:27017
+      - API_KEY=very_secret_api_key
+      - FLASK_APP=main.py
+    depends_on:
+      - mongodb
+
+volumes:
+  mongo-data:
+    driver: local

--- a/kubernetes-deploy.yaml
+++ b/kubernetes-deploy.yaml
@@ -40,6 +40,8 @@ spec:
             secretKeyRef:
               name: btc-secret
               key: API_KEY
+        - name: FLASK_APP
+          value: "main.py"
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
this fixes the file names for Flask so it'd be recognized during the container startup.
Alternately, one can launch the one stack with a single `podman-compose up` command. Note the scrape interval is set to 5m so we'd need to wait a bit for warm up and let BPC fetch the data first
